### PR TITLE
main.js: Remove one-off 'img' variable

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,8 +1,7 @@
 (function(exports) {
 
   function isSrcsetImplemented() {
-    var img = new Image();
-    return 'srcset' in img;
+    return 'srcset' in new Image();
   }
 
   function main() {


### PR DESCRIPTION
Might as well evaluate it inline without ever assigning it.
